### PR TITLE
Reorg, add HostObjectType, bury Rc<HostContextImpl>

### DIFF
--- a/src/host_context/host_object.rs
+++ b/src/host_context/host_object.rs
@@ -1,0 +1,59 @@
+use super::ValInContext;
+use im_rc::{OrdMap, Vector};
+use stellar_xdr::ScObjectType;
+
+use num_bigint::BigInt;
+use num_rational::BigRational;
+
+type HostMap = OrdMap<ValInContext, ValInContext>;
+type HostVec = Vector<ValInContext>;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HostObject {
+    Box(ValInContext),
+    Vec(HostVec),
+    Map(HostMap),
+    U64(u64),
+    I64(i64),
+    Str(String),
+    Bin(Vec<u8>),
+    BigInt(BigInt),
+    BigRat(BigRational),
+    // TODO: waiting for Ord, PartialOrd on these
+    //LedgerKey(LedgerKey),
+    //Operation(Operation),
+    //OperationResult(OperationResult),
+    //Transaction(Transaction),
+    //Asset(Asset),
+    //Price(Price),
+    //AccountID(AccountID)
+}
+
+pub trait HostObjectType: Sized {
+    fn get_type() -> ScObjectType;
+    fn inject(self) -> HostObject;
+}
+
+macro_rules! declare_host_object_type {
+    ($TY:ty, $CODE:ident, $CTOR:ident) => {
+        impl HostObjectType for $TY {
+            fn get_type() -> ScObjectType {
+                ScObjectType::$CODE
+            }
+
+            fn inject(self) -> HostObject {
+                HostObject::$CTOR(self)
+            }
+        }
+    };
+}
+
+declare_host_object_type!(ValInContext, ScoBox, Box);
+declare_host_object_type!(HostMap, ScoMap, Map);
+declare_host_object_type!(HostVec, ScoVec, Vec);
+declare_host_object_type!(u64, ScoU64, U64);
+declare_host_object_type!(i64, ScoI64, I64);
+declare_host_object_type!(String, ScoString, Str);
+declare_host_object_type!(Vec<u8>, ScoBinary, Bin);
+declare_host_object_type!(BigInt, ScoBigint, BigInt);
+declare_host_object_type!(BigRational, ScoBigrat, BigRat);

--- a/src/host_context/val_in_context.rs
+++ b/src/host_context/val_in_context.rs
@@ -1,0 +1,102 @@
+use super::HostContextImpl;
+use crate::{require, val::Tag, Val};
+use crate::{BitSet, Status, Symbol, ValType};
+use std::cmp::Ordering;
+use std::rc::{Rc, Weak};
+
+#[derive(Clone)]
+pub struct ValInContext {
+    pub(crate) ctx: Weak<HostContextImpl>,
+    pub(crate) val: Val,
+}
+
+impl ValInContext {
+    pub(crate) fn get_context(&self) -> Rc<HostContextImpl> {
+        self.ctx
+            .upgrade()
+            .expect("ValInContext.get_context() on expired context")
+    }
+    pub(crate) fn check_same_context(&self, other: &Self) -> Rc<HostContextImpl> {
+        let self_ctx = self.get_context();
+        let other_ctx = other.get_context();
+        require(Rc::ptr_eq(&self_ctx, &other_ctx));
+        self_ctx
+    }
+}
+
+impl Eq for ValInContext {}
+
+impl PartialEq for ValInContext {
+    fn eq(&self, other: &Self) -> bool {
+        let ctx = self.check_same_context(other);
+        if self.val.get_payload() == other.val.get_payload() {
+            // Fast path: bit-identical vals.
+            true
+        } else if self.val.get_tag() != Tag::Object || other.val.get_tag() != Tag::Object {
+            // Other fast path: non-identical non-objects, must be non-equal.
+            false
+        } else {
+            // Slow path: deep object comparison.
+            unsafe {
+                ctx.unchecked_visit_val_obj(self.val, |a| {
+                    ctx.unchecked_visit_val_obj(other.val, |b| a.eq(&b))
+                })
+            }
+        }
+    }
+}
+
+impl PartialOrd for ValInContext {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ValInContext {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let ctx = self.check_same_context(other);
+        let self_tag = self.val.get_tag();
+        let other_tag = other.val.get_tag();
+        if self_tag < other_tag {
+            Ordering::Less
+        } else if self_tag > other_tag {
+            Ordering::Greater
+        } else {
+            // Tags are equal so we only have to switch on one.
+            match self_tag {
+                Tag::U32 => {
+                    let a = unsafe { <u32 as ValType>::unchecked_from_val(self.val) };
+                    let b = unsafe { <u32 as ValType>::unchecked_from_val(other.val) };
+                    a.cmp(&b)
+                }
+                Tag::I32 => {
+                    let a = unsafe { <i32 as ValType>::unchecked_from_val(self.val) };
+                    let b = unsafe { <i32 as ValType>::unchecked_from_val(other.val) };
+                    a.cmp(&b)
+                }
+                Tag::Static => self.val.get_body().cmp(&other.val.get_body()),
+                Tag::Object => unsafe {
+                    ctx.unchecked_visit_val_obj(self.val, |a| {
+                        ctx.unchecked_visit_val_obj(other.val, |b| a.cmp(&b))
+                    })
+                },
+                Tag::Symbol => {
+                    let a = unsafe { <Symbol as ValType>::unchecked_from_val(self.val) };
+                    let b = unsafe { <Symbol as ValType>::unchecked_from_val(other.val) };
+                    a.cmp(&b)
+                }
+                Tag::BitSet => {
+                    let a = unsafe { <BitSet as ValType>::unchecked_from_val(self.val) };
+                    let b = unsafe { <BitSet as ValType>::unchecked_from_val(other.val) };
+                    a.cmp(&b)
+                }
+                Tag::Status => {
+                    let a = unsafe { <Status as ValType>::unchecked_from_val(self.val) };
+                    let b = unsafe { <Status as ValType>::unchecked_from_val(other.val) };
+                    a.cmp(&b)
+                }
+                Tag::Reserved => self.val.get_payload().cmp(&other.val.get_payload()),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make more of the object-adding type directed, make the Rc invisible to users, move code around for organization, implement a host function (map_new).