### PR TITLE
Update the xdr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 static_assertions = "1.1.0"
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "af3cee61b0d50d4dec2237050a7f12c0e6ed4ca0" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "dd016cd906ddd1efbe7e0b81d7bac9c07510200c" }
 im-rc = { version = "15.0.0", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-rational = { version = "0.4", optional = true }


### PR DESCRIPTION
### What

Update stellar-xdr to the latest commit. Update locations that used variable length arrays and opaques to use the `VecM` type.

### Why

Keep it up-to-date. Also, I'm starting work on the host interface, and I need the host and sdk libs to be using the same version of the XDR lib.

### Known limitations

The VecM type has some traits and functions implemented like TryFrom from a few types (Vec, slice, arrays, etc), AsRef (for slices), and a few functions like `iter`, `as_vec`, `to_vec`. And I noticed that `()` is commonly used as an error type in this crate, so I've also added a From impl for converting the errors from the xdr lib into `()` so we can map automatically. 

Please let me know if there are other conveniences I should add, specifically for the VecM.