### PR TITLE
Remove convenience-only generic fns from Host trait

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::ScObjectType;
 
-use crate::{or_abort::OrAbort, ValType};
+use crate::ValType;
 
 use super::{Object, Val};
 use core::any;
@@ -83,18 +83,6 @@ pub trait Host {
     fn obj_to_u64(&mut self, u: Object) -> u64;
     fn obj_from_i64(&mut self, i: i64) -> Object;
     fn obj_to_i64(&mut self, i: Object) -> i64;
-
-    fn val_from<HC: HostConvertable>(&mut self, v: HC) -> Val {
-        v.into_val(self)
-    }
-
-    fn try_val_into<HC: HostConvertable>(&mut self, v: Val) -> Option<HC> {
-        HC::try_from_val(v, self)
-    }
-
-    fn val_into<HC: HostConvertable>(&mut self, v: Val) -> HC {
-        self.try_val_into::<HC>(v).or_abort()
-    }
 
     fn map_new(&mut self) -> Object;
     fn map_put(&mut self, m: Object, k: Val, v: Val) -> Object;

--- a/src/host_context.rs
+++ b/src/host_context.rs
@@ -356,14 +356,14 @@ mod test {
     use stellar_xdr::{ScObject, ScObjectType, ScVal, ScVec};
 
     use super::HostContext;
-    use crate::{or_abort::OrAbort, Host, Object};
+    use crate::{or_abort::OrAbort, Host, HostConvertable, Object};
 
     #[test]
     fn i64_roundtrip() {
         let mut host = HostContext::default();
         let i = 12345_i64;
-        let v = host.val_from(i);
-        let j = host.val_into::<i64>(v);
+        let v = i.into_val(&mut host);
+        let j = i64::try_from_val(v, &mut host).or_abort();
         assert_eq!(i, j);
     }
 


### PR DESCRIPTION
### What

Remove the convenience-only generic fns from the Host trait.

### Why

They prevent using the Host trait in dyn trait situations. As far as I can tell these functions on the Host trait only exist out of convenience but otherwise don't need to be part of the interface that the Host trait provides.

As a bonus of this change, any code doing these conversions will look the same rather than being one of the two different ways of doing conversions.

### Known limitations

N/A