### PR TITLE
Remove TryFrom i64<->Val impls that can be footguns

### DIFF
--- a/src/val.rs
+++ b/src/val.rs
@@ -85,30 +85,6 @@ macro_rules! declare_tryfrom {
     };
 }
 
-impl TryFrom<Val> for i64 {
-    type Error = ();
-
-    fn try_from(value: Val) -> Result<Self, Self::Error> {
-        if value.is_u63() {
-            Ok(unsafe { value.unchecked_as_u63() })
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl TryFrom<i64> for Val {
-    type Error = ();
-
-    fn try_from(value: i64) -> Result<Self, Self::Error> {
-        if value >= 0 {
-            Ok(unsafe { Val::unchecked_from_u63(value) })
-        } else {
-            Err(())
-        }
-    }
-}
-
 declare_tryfrom!(());
 declare_tryfrom!(bool);
 declare_tryfrom!(u32);


### PR DESCRIPTION
### What

Remove the `TryFrom` impls for `i64`<->`Val`.

### Why

These `TryFrom` impls look like footguns when using `Val` in the contract SDK. It's too easy to call `.try_from` for `Val` -> `i64` when the developer should really be calling `i64::try_from_val`. If we give the developer the choice we're encouraging a leak of the u63 concept into developer code.

As far as I can tell these `TryFrom` impls have no use in the host crate, and so I suspect they are just a holdover from the SDK.

### Known limitations

I'm not sure if there's a future use for these. If there is a future use for these, is there a way to hide them from the SDK so that when the SDK imports and uses Val, it doesn't get them?