### PR TITLE
Add stellar-xdr/std to host_context feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 
 [dependencies]
 static_assertions = "1.1.0"
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "dd016cd906ddd1efbe7e0b81d7bac9c07510200c" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3ebdefd6c78719ede6b294aa64e13077d2a", default-features = false }
 im-rc = { version = "15.0.0", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-rational = { version = "0.4", optional = true }
 
 [features]
 default = ["host_context"]
-host_context = ["im-rc", "num-bigint", "num-rational"]
+host_context = ["stellar-xdr/std", "im-rc", "num-bigint", "num-rational"]
 
 [target.'cfg(not(target_family="wasm"))'.features]
 default = ["host_context"]


### PR DESCRIPTION
### What

Include `stellar-xdr`'s `std` feature in the `host_context` feature, and disable stellar-xdr's default features.

### Why

We only want to import `stellar-xdr` with `std` if we're building for the `host_context`, because when we're building for the guest context, we are avoiding use of `std`.

### Known limitations

N/A
